### PR TITLE
[IT-84875] Fix error decimal var to interger

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: pokerops
 name: r2
-version: 0.0.2
+version: 0.0.3
 readme: README.md
 authors:
   - Carlos Gonzalez <43476850+carlosgo13@users.noreply.github.com>

--- a/playbooks/sync.yml
+++ b/playbooks/sync.yml
@@ -11,7 +11,7 @@
   vars_files:
     - main.yml
   vars:
-    r2_object_sync_retries: "{{ (_r2_object_sync_timeout | int) / (_r2_object_sync_delay | int) }}"
+    r2_object_sync_retries: "{{ ((_r2_object_sync_timeout | int) / (_r2_object_sync_delay | int)) | int }}"
   tasks:
     - name: Check and initialize play facts
       tags: always


### PR DESCRIPTION
{"msg": "the field 'retries' has an invalid value ({{ r2_object_sync_retries }}), and could not be converted to an int.The error was: invalid literal for int() with base 10: '60.0'\n\nThe error appears to be in '/home/it_mlaurent/.ansible/collections/ansible_collections/pokerops/r2/playbooks/sync.yml': line 118, column 11, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n        - name: Wait for R2 sync operations to complete\n          ^ here\n"}